### PR TITLE
Fix incorrect array reference

### DIFF
--- a/Loader/Loader.go
+++ b/Loader/Loader.go
@@ -247,7 +247,7 @@ func GeneratePE(beacon_PE string) map[string]string {
 	Beacon_Stage_p2.Variables = make(map[string]string)
 	if beacon_PE == "" {
 		PE_Num, _ := strconv.Atoi(Utils.GenerateNumer(0, 25))
-		Beacon_Stage_p2.Variables["pe"] = Struct.Post_EX_Process_Name[PE_Num]
+		Beacon_Stage_p2.Variables["pe"] = Struct.Peclone_list[PE_Num]
 	}
 	if beacon_PE != "" {
 		PE_Num, _ := strconv.Atoi(beacon_PE)


### PR DESCRIPTION
Array for GeneratePE function without beacon_PE arg specified incorrectly referenced the Post_EX_Process_Name array,
- PE_Num would be assigned 0-26, and was crashing out if 17+, as the Post_EX_Process_Name array only has 17 values. Think this is the incorrect array altogether.

Corrected to Peclone_list - In line with the PEclone_list array queried when beacon_PE arg is specified.

