### PR TITLE
CS 4.6 Support

### DIFF
--- a/Loader/Loader.go
+++ b/Loader/Loader.go
@@ -13,24 +13,27 @@ import (
 )
 
 type FlagOptions struct {
-	sleeptime               string
-	jitter                  string
-	useragent               string
-	uri                     string
-	customuri               string
-	beacon_PE               string
-	processinject_min_alloc string
-	Post_EX_Process_Name    string
-	metadata                string
-	injector                string
-	Host                    string
-	outFile                 string
-	Profile                 string
-	ProfilePath             string
-	cert_password           string
-	custom_cert             string
-	CDN                     string
-	Yaml                    string
+	sleeptime                string
+	jitter                   string
+	useragent                string
+	uri                      string
+	customuri                string
+	beacon_PE                string
+	processinject_min_alloc  string
+	Post_EX_Process_Name     string
+	metadata                 string
+	injector                 string
+	Host                     string
+	outFile                  string
+	Profile                  string
+	ProfilePath              string
+	cert_password            string
+	custom_cert              string
+	CDN                      string
+	Yaml                     string
+	tasks_max_size           string
+	tasks_proxy_max_size     string
+	tasks_dns_proxy_max_size string
 }
 
 type Beacon_Com struct {
@@ -64,7 +67,7 @@ type Beacon_SSL struct {
 var num_Profile int
 var Post bool
 
-func GenerateOptions(stage, sleeptime, jitter, useragent, uri, customuri, customuriGET, customuriPOST, beacon_PE, processinject_min_alloc, Post_EX_Process_Name, metadata, injector, Host, Profile, ProfilePath, outFile, custom_cert, cert_password, CDN, CDN_Value, datajitter, Keylogger string, Forwarder bool) {
+func GenerateOptions(stage, sleeptime, jitter, useragent, uri, customuri, customuriGET, customuriPOST, beacon_PE, processinject_min_alloc, Post_EX_Process_Name, metadata, injector, Host, Profile, ProfilePath, outFile, custom_cert, cert_password, CDN, CDN_Value, datajitter, Keylogger string, Forwarder bool, tasks_max_size string, tasks_proxy_max_size string, tasks_dns_proxy_max_size string) {
 	Beacon_Com := &Beacon_Com{}
 	Beacon_Stage_p1 := &Beacon_Stage_p1{}
 	Beacon_Stage_p2 := &Beacon_Stage_p2{}
@@ -77,7 +80,7 @@ func GenerateOptions(stage, sleeptime, jitter, useragent, uri, customuri, custom
 	var HostStageMessage string
 
 	fmt.Println("[*] Preparing Varibles...")
-	HostStageMessage, Beacon_Com.Variables = GenerateComunication(stage, sleeptime, jitter, useragent, datajitter)
+	HostStageMessage, Beacon_Com.Variables = GenerateComunication(stage, sleeptime, jitter, useragent, datajitter, tasks_max_size, tasks_proxy_max_size, tasks_dns_proxy_max_size)
 	Beacon_PostEX.Variables = GeneratePostProcessName(Post_EX_Process_Name, Keylogger)
 	Beacon_GETPOST.Variables = GenerateHTTPVaribles(Host, metadata, uri, customuri, customuriGET, customuriPOST, CDN, CDN_Value, Profile, Forwarder)
 	Beacon_Stage_p2.Variables = GeneratePE(beacon_PE)
@@ -99,7 +102,7 @@ func GenerateOptions(stage, sleeptime, jitter, useragent, uri, customuri, custom
 	fmt.Println("[+] Happy Hacking")
 }
 
-func GenerateComunication(stage, sleeptime, jitter, useragent, datajitter string) (string, map[string]string) {
+func GenerateComunication(stage, sleeptime, jitter, useragent, datajitter string, tasks_max_size string, tasks_proxy_max_size string, tasks_dns_proxy_max_size string) (string, map[string]string) {
 	Beacon_Com := &Beacon_Com{}
 	Beacon_Com.Variables = make(map[string]string)
 	var HostStageMessage string
@@ -126,6 +129,22 @@ func GenerateComunication(stage, sleeptime, jitter, useragent, datajitter string
 	}
 	if datajitter == "" {
 		Beacon_Com.Variables["datajitter"] = Utils.GenerateNumer(10, 60)
+	}
+
+	if tasks_max_size != "" {
+		Beacon_Com.Variables["tasks_max_size"] = tasks_max_size
+	} else {
+		Beacon_Com.Variables["tasks_max_size"] = "1048576"
+	}
+	if tasks_proxy_max_size != "" {
+		Beacon_Com.Variables["tasks_proxy_max_size"] = tasks_proxy_max_size
+	} else {
+		Beacon_Com.Variables["tasks_proxy_max_size"] = "921600"
+	}
+	if tasks_dns_proxy_max_size != "" {
+		Beacon_Com.Variables["tasks_dns_proxy_max_size"] = tasks_dns_proxy_max_size
+	} else {
+		Beacon_Com.Variables["tasks_dns_proxy_max_size"] = "71680"
 	}
 	SSH_Numb, _ := strconv.Atoi(Utils.GenerateNumer(0, 4))
 	Beacon_Com.Variables["SSH_Banner"] = Struct.SSH_Banner[SSH_Numb]

--- a/README.md
+++ b/README.md
@@ -153,6 +153,12 @@ Usage of ./SourcePoint:
         [*] Linux
         [*] Mac
         [*] Custom - Whatever string you specify will be used as the user agent
+  -TasksMaxSize string
+        The maximum size (in bytes) of task(s) and proxy data that can be transferred through a communication channel at a check in
+  -TasksProxyMaxSize string
+        The maximum size (in bytes) of proxy data to transfer via the communication channel at a check in.
+  -TasksDnsProxyMaxSize string
+        The maximum size (in bytes) of proxy data to transfer via the DNS communication channel at a check in.
   -Yaml string
         Path to the Yaml config file
 ```

--- a/SourcePoint.go
+++ b/SourcePoint.go
@@ -12,59 +12,65 @@ import (
 )
 
 type FlagOptions struct {
-	stage                   string
-	sleeptime               string
-	jitter                  string
-	useragent               string
-	uri                     string
-	customuri               string
-	customuriGET            string
-	customuriPOST           string
-	beacon_PE               string
-	processinject_min_alloc string
-	Post_EX_Process_Name    string
-	metadata                string
-	injector                string
-	Host                    string
-	outFile                 string
-	Profile                 string
-	ProfilePath             string
-	cert_password           string
-	custom_cert             string
-	CDN                     string
-	CDN_Value               string
-	Datajitter              string
-	Keylogger               string
-	Forwarder               bool
-	Yaml                    string
+	stage                     string
+	sleeptime                 string
+	jitter                    string
+	useragent                 string
+	uri                       string
+	customuri                 string
+	customuriGET              string
+	customuriPOST             string
+	beacon_PE                 string
+	processinject_min_alloc   string
+	Post_EX_Process_Name      string
+	metadata                  string
+	injector                  string
+	Host                      string
+	outFile                   string
+	Profile                   string
+	ProfilePath               string
+	cert_password             string
+	custom_cert               string
+	CDN                       string
+	CDN_Value                 string
+	Datajitter                string
+	Keylogger                 string
+	Forwarder                 bool
+	Yaml                      string
+  tasks_max_size            string
+  tasks_proxy_max_size      string
+  tasks_dns_proxy_max_size  string
 }
 
 type conf struct {
-	Host                 string `yaml:"Host"`
-	Stage                string `yaml:"Stage"`
-	Keystore             string `yaml:"Keystore"`
-	Password             string `yaml:"Password"`
-	Metadata             string `yaml:"Metadata"`
-	Injector             string `yaml:"Injector"`
-	Outfile              string `yaml:"Outfile"`
-	PE_Clone             string `yaml:"PE_Clone"`
-	Profile              string `yaml:"Profile"`
-	Post_EX_Process_Name string `yaml:"Post-EX Processname"`
-	ProfilePath          string `yaml:"ProfilePath"`
-	Allocation           string `yaml:"allocation"`
-	Jitter               string `yaml:"Jitter"`
-	Debug                bool   `yaml:"Debug"`
-	Sleep                string `yaml:"Sleep"`
-	Uri                  string `yaml:"Uri"`
-	Customuri            string `yaml:"Customuri"`
-	CustomuriGET         string `yaml:"CustomuriGET"`
-	CustomuriPOST        string `yaml:"CustomuriPOST"`
-	CDN                  string `yaml:"CDN"`
-	CDN_Value            string `yaml:"CDN_Value"`
-	Useragent            string `yaml:"Useragent"`
-	Datajitter           string `yaml:"Datajitter"`
-	Keylogger            string `yaml:"Keylogger"`
-	Forwarder            bool   `yaml:"Forwarder"`
+	Host                  string `yaml:"Host"`
+	Stage                 string `yaml:"Stage"`
+	Keystore              string `yaml:"Keystore"`
+	Password              string `yaml:"Password"`
+	Metadata              string `yaml:"Metadata"`
+	Injector              string `yaml:"Injector"`
+	Outfile               string `yaml:"Outfile"`
+	PE_Clone              string `yaml:"PE_Clone"`
+	Profile               string `yaml:"Profile"`
+	Post_EX_Process_Name  string `yaml:"Post-EX Processname"`
+	ProfilePath           string `yaml:"ProfilePath"`
+	Allocation            string `yaml:"allocation"`
+	Jitter                string `yaml:"Jitter"`
+	Debug                 bool   `yaml:"Debug"`
+	Sleep                 string `yaml:"Sleep"`
+	Uri                   string `yaml:"Uri"`
+	Customuri             string `yaml:"Customuri"`
+	CustomuriGET          string `yaml:"CustomuriGET"`
+	CustomuriPOST         string `yaml:"CustomuriPOST"`
+	CDN                   string `yaml:"CDN"`
+	CDN_Value             string `yaml:"CDN_Value"`
+	Useragent             string `yaml:"Useragent"`
+	Datajitter            string `yaml:"Datajitter"`
+	Keylogger             string `yaml:"Keylogger"`
+	Forwarder             bool   `yaml:"Forwarder"`
+  TasksMaxSize          string `yaml:TasksMaxSize`
+  TasksProxyMaxSize     string `yaml:TasksProxyMaxSize`
+  TasksDnsProxyMaxSize  string `yaml:TasksDnsProxyMaxSize`
 }
 
 func (c *conf) getConf(yamlfile string) *conf {
@@ -82,7 +88,10 @@ func (c *conf) getConf(yamlfile string) *conf {
 }
 
 func options() *FlagOptions {
-	sleeptime := flag.String("Sleep", "", "Initial beacon sleep time")
+	tasks_max_size := flag.String("TasksMaxSize", "1048576", "The maximum size (in bytes) of task(s) and proxy data that can be transferred through a communication channel at a check in")
+	tasks_proxy_max_size := flag.String("TasksProxyMaxSize", "921600", "The maximum size (in bytes) of proxy data to transfer via the communication channel at a check in")
+	tasks_dns_proxy_max_size := flag.String("TasksDnsProxyMaxSize", "71680", "The maximum size (in bytes) of proxy data to transfer via the DNS communication channel at a check in")
+  sleeptime := flag.String("Sleep", "", "Initial beacon sleep time")
 	stage := flag.String("Stage", "false", "Disable host staging (Default: False)")
 	jitter := flag.String("Jitter", "", "Jitter percentage for beacon call home")
 	useragent := flag.String("Useragent", "", `UserAgent string for the beacon to use (Leave blank to randomly select one):
@@ -179,7 +188,7 @@ func options() *FlagOptions {
 	Forwarder := flag.Bool("Forwarder", false, "Enabled the X-forwarded-For header (Good for when your C2 is behind a redirector)")
 	Yaml := flag.String("Yaml", "", "Path to the Yaml config file")
 	flag.Parse()
-	return &FlagOptions{stage: *stage, sleeptime: *sleeptime, jitter: *jitter, useragent: *useragent, uri: *uri, customuri: *customuri, customuriGET: *customuriGET, customuriPOST: *customuriPOST, beacon_PE: *beacon_PE, processinject_min_alloc: *processinject_min_alloc, Post_EX_Process_Name: *Post_EX_Process_Name, metadata: *metadata, injector: *injector, Host: *Host, Profile: *Profile, ProfilePath: *ProfilePath, outFile: *outFile, custom_cert: *custom_cert, cert_password: *cert_password, CDN: *CDN, CDN_Value: *CDN_Value, Yaml: *Yaml, Datajitter: *Datajitter, Keylogger: *Keylogger, Forwarder: *Forwarder}
+  return &FlagOptions{stage: *stage, sleeptime: *sleeptime, jitter: *jitter, useragent: *useragent, uri: *uri, customuri: *customuri, customuriGET: *customuriGET, customuriPOST: *customuriPOST, beacon_PE: *beacon_PE, processinject_min_alloc: *processinject_min_alloc, Post_EX_Process_Name: *Post_EX_Process_Name, metadata: *metadata, injector: *injector, Host: *Host, Profile: *Profile, ProfilePath: *ProfilePath, outFile: *outFile, custom_cert: *custom_cert, cert_password: *cert_password, CDN: *CDN, CDN_Value: *CDN_Value, Yaml: *Yaml, Datajitter: *Datajitter, Keylogger: *Keylogger, Forwarder: *Forwarder, tasks_max_size: *tasks_max_size, tasks_proxy_max_size: *tasks_proxy_max_size, tasks_dns_proxy_max_size: *tasks_dns_proxy_max_size}
 
 }
 
@@ -223,6 +232,9 @@ func main() {
 		opt.Datajitter = c.Datajitter
 		opt.Keylogger = c.Keylogger
 		opt.Forwarder = c.Forwarder
+    opt.tasks_max_size = c.TasksMaxSize
+    opt.tasks_proxy_max_size = c.TasksProxyMaxSize
+    opt.tasks_dns_proxy_max_size = c.TasksDnsProxyMaxSize
 	}
 	if opt.outFile == "" {
 		log.Fatal("Error: Please provide a file name to save the profile into")
@@ -237,5 +249,5 @@ func main() {
 		log.Fatal("Error: When using CustomuriGET/CustomuriPOST, both must be sepecified")
 	}
 
-	Loader.GenerateOptions(opt.stage, opt.sleeptime, opt.jitter, opt.useragent, opt.uri, opt.customuri, opt.customuriGET, opt.customuriPOST, opt.beacon_PE, opt.processinject_min_alloc, opt.Post_EX_Process_Name, opt.metadata, opt.injector, opt.Host, opt.Profile, opt.ProfilePath, opt.outFile, opt.custom_cert, opt.cert_password, opt.CDN, opt.CDN_Value, opt.Datajitter, opt.Keylogger, opt.Forwarder)
+	Loader.GenerateOptions(opt.stage, opt.sleeptime, opt.jitter, opt.useragent, opt.uri, opt.customuri, opt.customuriGET, opt.customuriPOST, opt.beacon_PE, opt.processinject_min_alloc, opt.Post_EX_Process_Name, opt.metadata, opt.injector, opt.Host, opt.Profile, opt.ProfilePath, opt.outFile, opt.custom_cert, opt.cert_password, opt.CDN, opt.CDN_Value, opt.Datajitter, opt.Keylogger, opt.Forwarder, opt.tasks_max_size, opt.tasks_proxy_max_size, opt.tasks_dns_proxy_max_size)
 }

--- a/SourcePoint.go
+++ b/SourcePoint.go
@@ -12,65 +12,65 @@ import (
 )
 
 type FlagOptions struct {
-	stage                     string
-	sleeptime                 string
-	jitter                    string
-	useragent                 string
-	uri                       string
-	customuri                 string
-	customuriGET              string
-	customuriPOST             string
-	beacon_PE                 string
-	processinject_min_alloc   string
-	Post_EX_Process_Name      string
-	metadata                  string
-	injector                  string
-	Host                      string
-	outFile                   string
-	Profile                   string
-	ProfilePath               string
-	cert_password             string
-	custom_cert               string
-	CDN                       string
-	CDN_Value                 string
-	Datajitter                string
-	Keylogger                 string
-	Forwarder                 bool
-	Yaml                      string
-  tasks_max_size            string
-  tasks_proxy_max_size      string
-  tasks_dns_proxy_max_size  string
+	stage                    string
+	sleeptime                string
+	jitter                   string
+	useragent                string
+	uri                      string
+	customuri                string
+	customuriGET             string
+	customuriPOST            string
+	beacon_PE                string
+	processinject_min_alloc  string
+	Post_EX_Process_Name     string
+	metadata                 string
+	injector                 string
+	Host                     string
+	outFile                  string
+	Profile                  string
+	ProfilePath              string
+	cert_password            string
+	custom_cert              string
+	CDN                      string
+	CDN_Value                string
+	Datajitter               string
+	Keylogger                string
+	Forwarder                bool
+	tasks_max_size           string
+	tasks_proxy_max_size     string
+	tasks_dns_proxy_max_size string
+	Yaml                     string
 }
 
 type conf struct {
-	Host                  string `yaml:"Host"`
-	Stage                 string `yaml:"Stage"`
-	Keystore              string `yaml:"Keystore"`
-	Password              string `yaml:"Password"`
-	Metadata              string `yaml:"Metadata"`
-	Injector              string `yaml:"Injector"`
-	Outfile               string `yaml:"Outfile"`
-	PE_Clone              string `yaml:"PE_Clone"`
-	Profile               string `yaml:"Profile"`
-	Post_EX_Process_Name  string `yaml:"Post-EX Processname"`
-	ProfilePath           string `yaml:"ProfilePath"`
-	Allocation            string `yaml:"allocation"`
-	Jitter                string `yaml:"Jitter"`
-	Debug                 bool   `yaml:"Debug"`
-	Sleep                 string `yaml:"Sleep"`
-	Uri                   string `yaml:"Uri"`
-	Customuri             string `yaml:"Customuri"`
-	CustomuriGET          string `yaml:"CustomuriGET"`
-	CustomuriPOST         string `yaml:"CustomuriPOST"`
-	CDN                   string `yaml:"CDN"`
-	CDN_Value             string `yaml:"CDN_Value"`
-	Useragent             string `yaml:"Useragent"`
-	Datajitter            string `yaml:"Datajitter"`
-	Keylogger             string `yaml:"Keylogger"`
-	Forwarder             bool   `yaml:"Forwarder"`
-  TasksMaxSize          string `yaml:TasksMaxSize`
-  TasksProxyMaxSize     string `yaml:TasksProxyMaxSize`
-  TasksDnsProxyMaxSize  string `yaml:TasksDnsProxyMaxSize`
+	Host                 string `yaml:"Host"`
+	Stage                string `yaml:"Stage"`
+	Keystore             string `yaml:"Keystore"`
+	Password             string `yaml:"Password"`
+	Metadata             string `yaml:"Metadata"`
+	Injector             string `yaml:"Injector"`
+	Outfile              string `yaml:"Outfile"`
+	PE_Clone             string `yaml:"PE_Clone"`
+	Profile              string `yaml:"Profile"`
+	Post_EX_Process_Name string `yaml:"Post-EX Processname"`
+	ProfilePath          string `yaml:"ProfilePath"`
+	Allocation           string `yaml:"allocation"`
+	Jitter               string `yaml:"Jitter"`
+	Debug                bool   `yaml:"Debug"`
+	Sleep                string `yaml:"Sleep"`
+	Uri                  string `yaml:"Uri"`
+	Customuri            string `yaml:"Customuri"`
+	CustomuriGET         string `yaml:"CustomuriGET"`
+	CustomuriPOST        string `yaml:"CustomuriPOST"`
+	CDN                  string `yaml:"CDN"`
+	CDN_Value            string `yaml:"CDN_Value"`
+	Useragent            string `yaml:"Useragent"`
+	Datajitter           string `yaml:"Datajitter"`
+	Keylogger            string `yaml:"Keylogger"`
+	Forwarder            bool   `yaml:"Forwarder"`
+	TasksMaxSize         string `yaml:"TasksMaxSize"`
+	TasksProxyMaxSize    string `yaml:"TasksProxyMaxSize"`
+	TasksDnsProxyMaxSize string `yaml:"TasksDnsProxyMaxSize"`
 }
 
 func (c *conf) getConf(yamlfile string) *conf {
@@ -88,10 +88,7 @@ func (c *conf) getConf(yamlfile string) *conf {
 }
 
 func options() *FlagOptions {
-	tasks_max_size := flag.String("TasksMaxSize", "1048576", "The maximum size (in bytes) of task(s) and proxy data that can be transferred through a communication channel at a check in")
-	tasks_proxy_max_size := flag.String("TasksProxyMaxSize", "921600", "The maximum size (in bytes) of proxy data to transfer via the communication channel at a check in")
-	tasks_dns_proxy_max_size := flag.String("TasksDnsProxyMaxSize", "71680", "The maximum size (in bytes) of proxy data to transfer via the DNS communication channel at a check in")
-  sleeptime := flag.String("Sleep", "", "Initial beacon sleep time")
+	sleeptime := flag.String("Sleep", "", "Initial beacon sleep time")
 	stage := flag.String("Stage", "false", "Disable host staging (Default: False)")
 	jitter := flag.String("Jitter", "", "Jitter percentage for beacon call home")
 	useragent := flag.String("Useragent", "", `UserAgent string for the beacon to use (Leave blank to randomly select one):
@@ -186,9 +183,12 @@ func options() *FlagOptions {
 	CDN_Value := flag.String("CDN-Value", "", "CDN cookie value (typically used for AzureEdge profiles)")
 	CDN := flag.String("CDN", "", "CDN cookie name (typically used for AzureEdge profiles)")
 	Forwarder := flag.Bool("Forwarder", false, "Enabled the X-forwarded-For header (Good for when your C2 is behind a redirector)")
+	tasks_max_size := flag.String("TasksMaxSize", "", "The maximum size (in bytes) of task(s) and proxy data that can be transferred through a communication channel at a check in")
+	tasks_proxy_max_size := flag.String("TasksProxyMaxSize", "", "The maximum size (in bytes) of proxy data to transfer via the communication channel at a check in")
+	tasks_dns_proxy_max_size := flag.String("TasksDnsProxyMaxSize", "", "The maximum size (in bytes) of proxy data to transfer via the DNS communication channel at a check in")
 	Yaml := flag.String("Yaml", "", "Path to the Yaml config file")
 	flag.Parse()
-  return &FlagOptions{stage: *stage, sleeptime: *sleeptime, jitter: *jitter, useragent: *useragent, uri: *uri, customuri: *customuri, customuriGET: *customuriGET, customuriPOST: *customuriPOST, beacon_PE: *beacon_PE, processinject_min_alloc: *processinject_min_alloc, Post_EX_Process_Name: *Post_EX_Process_Name, metadata: *metadata, injector: *injector, Host: *Host, Profile: *Profile, ProfilePath: *ProfilePath, outFile: *outFile, custom_cert: *custom_cert, cert_password: *cert_password, CDN: *CDN, CDN_Value: *CDN_Value, Yaml: *Yaml, Datajitter: *Datajitter, Keylogger: *Keylogger, Forwarder: *Forwarder, tasks_max_size: *tasks_max_size, tasks_proxy_max_size: *tasks_proxy_max_size, tasks_dns_proxy_max_size: *tasks_dns_proxy_max_size}
+	return &FlagOptions{stage: *stage, sleeptime: *sleeptime, jitter: *jitter, useragent: *useragent, uri: *uri, customuri: *customuri, customuriGET: *customuriGET, customuriPOST: *customuriPOST, beacon_PE: *beacon_PE, processinject_min_alloc: *processinject_min_alloc, Post_EX_Process_Name: *Post_EX_Process_Name, metadata: *metadata, injector: *injector, Host: *Host, Profile: *Profile, ProfilePath: *ProfilePath, outFile: *outFile, custom_cert: *custom_cert, cert_password: *cert_password, CDN: *CDN, CDN_Value: *CDN_Value, Yaml: *Yaml, Datajitter: *Datajitter, Keylogger: *Keylogger, Forwarder: *Forwarder, tasks_max_size: *tasks_max_size, tasks_proxy_max_size: *tasks_proxy_max_size, tasks_dns_proxy_max_size: *tasks_dns_proxy_max_size}
 
 }
 
@@ -232,9 +232,9 @@ func main() {
 		opt.Datajitter = c.Datajitter
 		opt.Keylogger = c.Keylogger
 		opt.Forwarder = c.Forwarder
-    opt.tasks_max_size = c.TasksMaxSize
-    opt.tasks_proxy_max_size = c.TasksProxyMaxSize
-    opt.tasks_dns_proxy_max_size = c.TasksDnsProxyMaxSize
+		opt.tasks_max_size = c.TasksMaxSize
+		opt.tasks_proxy_max_size = c.TasksProxyMaxSize
+		opt.tasks_dns_proxy_max_size = c.TasksDnsProxyMaxSize
 	}
 	if opt.outFile == "" {
 		log.Fatal("Error: Please provide a file name to save the profile into")
@@ -248,6 +248,6 @@ func main() {
 	if (opt.customuriGET != "" && opt.customuriPOST == "") || (opt.customuriGET == "" && opt.customuriPOST != "") {
 		log.Fatal("Error: When using CustomuriGET/CustomuriPOST, both must be sepecified")
 	}
-
+	fmt.Println(c.TasksMaxSize)
 	Loader.GenerateOptions(opt.stage, opt.sleeptime, opt.jitter, opt.useragent, opt.uri, opt.customuri, opt.customuriGET, opt.customuriPOST, opt.beacon_PE, opt.processinject_min_alloc, opt.Post_EX_Process_Name, opt.metadata, opt.injector, opt.Host, opt.Profile, opt.ProfilePath, opt.outFile, opt.custom_cert, opt.cert_password, opt.CDN, opt.CDN_Value, opt.Datajitter, opt.Keylogger, opt.Forwarder, opt.tasks_max_size, opt.tasks_proxy_max_size, opt.tasks_dns_proxy_max_size)
 }

--- a/Struct/Struct.go
+++ b/Struct/Struct.go
@@ -1279,6 +1279,11 @@ set sleeptime "{{.Variables.sleep}}";
 set jitter    "{{.Variables.jitter}}";
 set useragent "{{.Variables.useragent}}";
 
+# Task and Proxy Max Size
+set tasks_max_size "{{.Variables.tasks_max_size}}";
+set tasks_proxy_max_size "{{.Variables.tasks_proxy_max_size}}";
+set tasks_dns_proxy_max_size "{{.Variables.tasks_dns_proxy_max_size}}";
+
 set data_jitter "{{.Variables.datajitter}}";
 set smb_frame_header "";
 set pipename "{{.Variables.pipename}}";


### PR DESCRIPTION
https://www.cobaltstrike.com/blog/cobalt-strike-4-6-the-line-in-the-sand/
Execute-assembly 1MB Limit Increase
A number of users have been asking for this for quite some time, and the change that we made affect not only execute-assembly, but other tasks (eg. dllinject) as well. We have added three new settings to the Malleable C2 profile (tasks_max_size, tasks_proxy_max_size and tasks_dns_proxy_max_size) that can be used to control maximum size limits. Note that these settings need to be set prior to team server startup. If the size is increased at a later time, old artifacts will still use the previous size settings and tasks that are too large will be rejected.