### PR TITLE
fixing indexing error

### DIFF
--- a/Loader/Loader.go
+++ b/Loader/Loader.go
@@ -90,7 +90,7 @@ func GenerateOptions(stage, sleeptime, jitter, useragent, uri, customuri, custom
 	Build(custom_cert, cert_password, outFile, Beacon_Com, Beacon_Stage_p1, Beacon_Stage_p2, Beacon_Stage_p3, Process_Inject, Beacon_PostEX, Beacon_GETPOST, Beacon_GETPOST_Profile, Beacon_SSL)
 	fmt.Println(HostStageMessage)
 	PE := strings.Split(Beacon_Stage_p2.Variables["pe"], `;`)
-	PE_Name := strings.Split(PE[5], `"`)
+	PE_Name := strings.Split(PE[len(PE)-3], `"`)
 	fmt.Println("[*] Beacon DLL Spoofed To: " + PE_Name[1])
 	PEX := strings.Split(Beacon_PostEX.Variables["Post_EX_Process_Name"], `sysnative\\`)
 	PEX_Name := PEX[1]


### PR DESCRIPTION
- Fix for indexing error mentioned in https://github.com/Tylous/SourcePoint/issues/14
- Changed code to index length of the var - 3 to always reference the name.