### PR TITLE
Added DNS Support & Spawnto fix

### DIFF
--- a/Loader/Loader.go
+++ b/Loader/Loader.go
@@ -213,6 +213,8 @@ func GeneratePostProcessName(Post_EX_Process_Name, Keylogger string) map[string]
 		Beacon_PostEX.Variables["Keylogger"] = "SetWindowsHookEx"
 	} else {
 	}
+	pipe_number, _ := strconv.Atoi(Utils.GenerateNumer(0, 7))
+	Beacon_PostEX.Variables["pipename"] = Struct.Pipename_list[pipe_number]
 
 	return Beacon_PostEX.Variables
 }

--- a/Loader/Loader.go
+++ b/Loader/Loader.go
@@ -7,6 +7,10 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"math/rand"
+	"time"
+	"net"
+	"encoding/binary"
 
 	"github.com/Tylous/SourcePoint/Struct"
 	"github.com/Tylous/SourcePoint/Utils"
@@ -102,6 +106,36 @@ func GenerateOptions(stage, sleeptime, jitter, useragent, uri, customuri, custom
 	fmt.Println("[+] Happy Hacking")
 }
 
+func GetIpFromCidr(netw string) string {
+	_, ipv4Net, err := net.ParseCIDR(netw)
+	if err != nil {
+		log.Fatal(err)
+	}
+	mask := binary.BigEndian.Uint32(ipv4Net.Mask)
+	start := binary.BigEndian.Uint32(ipv4Net.IP)
+	finish := (start & mask) | (mask ^ 0xffffffff)
+	var hosts []string
+	for i := start + 1; i <= finish-1; i++ {
+		ip := make(net.IP, 4)
+		binary.BigEndian.PutUint32(ip, i)
+		hosts = append(hosts, ip.String())
+	}
+	rand.Seed(time.Now().Unix())
+	return hosts[rand.Intn(len(hosts))]
+}
+
+var seededRand *rand.Rand = rand.New(
+	rand.NewSource(time.Now().UnixNano()))
+
+func GenerateRandomString(length int) string {
+	var charset = "abcdefghijklmnopqrstuvwxyz"
+	b := make([]byte, length)
+	for i := range b {
+	  b[i] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(b)
+  }
+
 func GenerateComunication(stage, sleeptime, jitter, useragent, datajitter string, tasks_max_size string, tasks_proxy_max_size string, tasks_dns_proxy_max_size string) (string, map[string]string) {
 	Beacon_Com := &Beacon_Com{}
 	Beacon_Com.Variables = make(map[string]string)
@@ -146,6 +180,21 @@ func GenerateComunication(stage, sleeptime, jitter, useragent, datajitter string
 	} else {
 		Beacon_Com.Variables["tasks_dns_proxy_max_size"] = "71680"
 	}
+	//DNS Configs
+	Beacon_Com.Variables["dns_idle"] = GetIpFromCidr("73.140.245.0/24")
+	Beacon_Com.Variables["maxdns"] = "99"
+	Beacon_Com.Variables["dns_sleep"] = "300"
+	Beacon_Com.Variables["dns_ttl"] = "10"
+	Beacon_Com.Variables["dns_stager_prepend"] = "v=spf1 include:spf.protection.outlook.com -all"
+	Beacon_Com.Variables["dns_stager_subhost"] = GenerateRandomString(3) + "."
+	Beacon_Com.Variables["beacon"] = GenerateRandomString(3) + "."
+	Beacon_Com.Variables["get_A"] = GenerateRandomString(3) + "."
+	Beacon_Com.Variables["get_AAAA"] = GenerateRandomString(3) + "."
+	Beacon_Com.Variables["get_TXT"] = GenerateRandomString(3) + "."
+	Beacon_Com.Variables["put_metadata"] = GenerateRandomString(3) + "."
+	Beacon_Com.Variables["put_output"] = GenerateRandomString(3) + "."
+	Beacon_Com.Variables["ns_response"] = "idle"
+
 	SSH_Numb, _ := strconv.Atoi(Utils.GenerateNumer(0, 4))
 	Beacon_Com.Variables["SSH_Banner"] = Struct.SSH_Banner[SSH_Numb]
 

--- a/Loader/Loader.go
+++ b/Loader/Loader.go
@@ -38,6 +38,7 @@ type FlagOptions struct {
 	tasks_max_size           string
 	tasks_proxy_max_size     string
 	tasks_dns_proxy_max_size string
+	maxdns					 string
 }
 
 type Beacon_Com struct {
@@ -71,7 +72,7 @@ type Beacon_SSL struct {
 var num_Profile int
 var Post bool
 
-func GenerateOptions(stage, sleeptime, jitter, useragent, uri, customuri, customuriGET, customuriPOST, beacon_PE, processinject_min_alloc, Post_EX_Process_Name, metadata, injector, Host, Profile, ProfilePath, outFile, custom_cert, cert_password, CDN, CDN_Value, datajitter, Keylogger string, Forwarder bool, tasks_max_size string, tasks_proxy_max_size string, tasks_dns_proxy_max_size string) {
+func GenerateOptions(stage string, sleeptime string, jitter string, useragent string, uri string, customuri string, customuriGET string, customuriPOST string, beacon_PE string, processinject_min_alloc string, Post_EX_Process_Name string, metadata string, injector string, Host string, Profile string, ProfilePath string, outFile string, custom_cert string, cert_password string, CDN string, CDN_Value string, datajitter string, Keylogger string, Forwarder bool, tasks_max_size string, tasks_proxy_max_size string, tasks_dns_proxy_max_size string, maxdns string) {
 	Beacon_Com := &Beacon_Com{}
 	Beacon_Stage_p1 := &Beacon_Stage_p1{}
 	Beacon_Stage_p2 := &Beacon_Stage_p2{}
@@ -84,7 +85,7 @@ func GenerateOptions(stage, sleeptime, jitter, useragent, uri, customuri, custom
 	var HostStageMessage string
 
 	fmt.Println("[*] Preparing Varibles...")
-	HostStageMessage, Beacon_Com.Variables = GenerateComunication(stage, sleeptime, jitter, useragent, datajitter, tasks_max_size, tasks_proxy_max_size, tasks_dns_proxy_max_size)
+	HostStageMessage, Beacon_Com.Variables = GenerateComunication(stage, sleeptime, jitter, useragent, datajitter, tasks_max_size, tasks_proxy_max_size, tasks_dns_proxy_max_size, maxdns)
 	Beacon_PostEX.Variables = GeneratePostProcessName(Post_EX_Process_Name, Keylogger)
 	Beacon_GETPOST.Variables = GenerateHTTPVaribles(Host, metadata, uri, customuri, customuriGET, customuriPOST, CDN, CDN_Value, Profile, Forwarder)
 	Beacon_Stage_p2.Variables = GeneratePE(beacon_PE)
@@ -136,7 +137,7 @@ func GenerateRandomString(length int) string {
 	return string(b)
   }
 
-func GenerateComunication(stage, sleeptime, jitter, useragent, datajitter string, tasks_max_size string, tasks_proxy_max_size string, tasks_dns_proxy_max_size string) (string, map[string]string) {
+func GenerateComunication(stage, sleeptime, jitter, useragent, datajitter string, tasks_max_size string, tasks_proxy_max_size string, tasks_dns_proxy_max_size string, maxdns string) (string, map[string]string) {
 	Beacon_Com := &Beacon_Com{}
 	Beacon_Com.Variables = make(map[string]string)
 	var HostStageMessage string
@@ -164,7 +165,6 @@ func GenerateComunication(stage, sleeptime, jitter, useragent, datajitter string
 	if datajitter == "" {
 		Beacon_Com.Variables["datajitter"] = Utils.GenerateNumer(10, 60)
 	}
-
 	if tasks_max_size != "" {
 		Beacon_Com.Variables["tasks_max_size"] = tasks_max_size
 	} else {
@@ -182,7 +182,11 @@ func GenerateComunication(stage, sleeptime, jitter, useragent, datajitter string
 	}
 	//DNS Configs
 	Beacon_Com.Variables["dns_idle"] = GetIpFromCidr("73.140.245.0/24")
-	Beacon_Com.Variables["maxdns"] = "99"
+	if(maxdns) != "" {
+		Beacon_Com.Variables["maxdns"] = maxdns
+	} else {
+		Beacon_Com.Variables["maxdns"] = "200"
+	}
 	Beacon_Com.Variables["dns_sleep"] = "300"
 	Beacon_Com.Variables["dns_ttl"] = "10"
 	Beacon_Com.Variables["dns_stager_prepend"] = "v=spf1 include:spf.protection.outlook.com -all"

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Usage of ./SourcePoint:
         [5] bootcfg.exe
         [6] choice.exe
         [7] bootcfg.exe
-        [8] dtdump.exe
+        [8] w32tm.exe
         [9] expand.exe
         [10] fsutil.exe
         [11] gpupdate.exe

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Usage of ./SourcePoint:
         [*] SetWindowsHookEx (Uses SetWindowsHookEx API)
   -Keystore string
         SSL keystore name
+  -Maxdns
+        Maximum length of hostname when uploading data over DNS (0-255) (default 200)
   -Metadata string
         Specifies how to transform and embed metadata into the HTTP request:
         [*] base64

--- a/Sample.yaml
+++ b/Sample.yaml
@@ -27,3 +27,4 @@ Forwarder: False
 TasksMaxSize: 
 TasksProxyMaxSize:
 TasksDnsProxyMaxSize: 
+Maxdns: 

--- a/SourcePoint.go
+++ b/SourcePoint.go
@@ -39,6 +39,7 @@ type FlagOptions struct {
 	tasks_max_size           string
 	tasks_proxy_max_size     string
 	tasks_dns_proxy_max_size string
+	maxdns					 string
 	Yaml                     string
 }
 
@@ -67,10 +68,11 @@ type conf struct {
 	Useragent            string `yaml:"Useragent"`
 	Datajitter           string `yaml:"Datajitter"`
 	Keylogger            string `yaml:"Keylogger"`
-	Forwarder            bool   `yaml:"Forwarder"`
 	TasksMaxSize         string `yaml:"TasksMaxSize"`
 	TasksProxyMaxSize    string `yaml:"TasksProxyMaxSize"`
 	TasksDnsProxyMaxSize string `yaml:"TasksDnsProxyMaxSize"`
+	Maxdns				 string `yaml:"Maxdns"`
+	Forwarder            bool   `yaml:"Forwarder"`
 }
 
 func (c *conf) getConf(yamlfile string) *conf {
@@ -182,14 +184,14 @@ func options() *FlagOptions {
 	cert_password := flag.String("Password", "", "SSL certificate password")
 	CDN_Value := flag.String("CDN-Value", "", "CDN cookie value (typically used for AzureEdge profiles)")
 	CDN := flag.String("CDN", "", "CDN cookie name (typically used for AzureEdge profiles)")
-	Forwarder := flag.Bool("Forwarder", false, "Enabled the X-forwarded-For header (Good for when your C2 is behind a redirector)")
 	tasks_max_size := flag.String("TasksMaxSize", "", "The maximum size (in bytes) of task(s) and proxy data that can be transferred through a communication channel at a check in")
 	tasks_proxy_max_size := flag.String("TasksProxyMaxSize", "", "The maximum size (in bytes) of proxy data to transfer via the communication channel at a check in")
 	tasks_dns_proxy_max_size := flag.String("TasksDnsProxyMaxSize", "", "The maximum size (in bytes) of proxy data to transfer via the DNS communication channel at a check in")
+	maxdns := flag.String("Maxdns", "", "Maximum length of hostname when uploading data over DNS (0-255) (default 200)")
+	Forwarder := flag.Bool("Forwarder", false, "Enabled the X-forwarded-For header (Good for when your C2 is behind a redirector)")
 	Yaml := flag.String("Yaml", "", "Path to the Yaml config file")
 	flag.Parse()
-	return &FlagOptions{stage: *stage, sleeptime: *sleeptime, jitter: *jitter, useragent: *useragent, uri: *uri, customuri: *customuri, customuriGET: *customuriGET, customuriPOST: *customuriPOST, beacon_PE: *beacon_PE, processinject_min_alloc: *processinject_min_alloc, Post_EX_Process_Name: *Post_EX_Process_Name, metadata: *metadata, injector: *injector, Host: *Host, Profile: *Profile, ProfilePath: *ProfilePath, outFile: *outFile, custom_cert: *custom_cert, cert_password: *cert_password, CDN: *CDN, CDN_Value: *CDN_Value, Yaml: *Yaml, Datajitter: *Datajitter, Keylogger: *Keylogger, Forwarder: *Forwarder, tasks_max_size: *tasks_max_size, tasks_proxy_max_size: *tasks_proxy_max_size, tasks_dns_proxy_max_size: *tasks_dns_proxy_max_size}
-
+	return &FlagOptions{stage: *stage, sleeptime: *sleeptime, jitter: *jitter, useragent: *useragent, uri: *uri, customuri: *customuri, customuriGET: *customuriGET, customuriPOST: *customuriPOST, beacon_PE: *beacon_PE, processinject_min_alloc: *processinject_min_alloc, Post_EX_Process_Name: *Post_EX_Process_Name, metadata: *metadata, injector: *injector, Host: *Host, Profile: *Profile, ProfilePath: *ProfilePath, outFile: *outFile, custom_cert: *custom_cert, cert_password: *cert_password, CDN: *CDN, CDN_Value: *CDN_Value, Yaml: *Yaml, Datajitter: *Datajitter, Keylogger: *Keylogger, Forwarder: *Forwarder, tasks_max_size: *tasks_max_size, tasks_proxy_max_size: *tasks_proxy_max_size, tasks_dns_proxy_max_size: *tasks_dns_proxy_max_size, maxdns: *maxdns}
 }
 
 func main() {
@@ -235,6 +237,7 @@ func main() {
 		opt.tasks_max_size = c.TasksMaxSize
 		opt.tasks_proxy_max_size = c.TasksProxyMaxSize
 		opt.tasks_dns_proxy_max_size = c.TasksDnsProxyMaxSize
+		opt.maxdns = c.Maxdns
 	}
 	if opt.outFile == "" {
 		log.Fatal("Error: Please provide a file name to save the profile into")
@@ -248,6 +251,5 @@ func main() {
 	if (opt.customuriGET != "" && opt.customuriPOST == "") || (opt.customuriGET == "" && opt.customuriPOST != "") {
 		log.Fatal("Error: When using CustomuriGET/CustomuriPOST, both must be sepecified")
 	}
-	fmt.Println(c.TasksMaxSize)
-	Loader.GenerateOptions(opt.stage, opt.sleeptime, opt.jitter, opt.useragent, opt.uri, opt.customuri, opt.customuriGET, opt.customuriPOST, opt.beacon_PE, opt.processinject_min_alloc, opt.Post_EX_Process_Name, opt.metadata, opt.injector, opt.Host, opt.Profile, opt.ProfilePath, opt.outFile, opt.custom_cert, opt.cert_password, opt.CDN, opt.CDN_Value, opt.Datajitter, opt.Keylogger, opt.Forwarder, opt.tasks_max_size, opt.tasks_proxy_max_size, opt.tasks_dns_proxy_max_size)
+	Loader.GenerateOptions(opt.stage, opt.sleeptime, opt.jitter, opt.useragent, opt.uri, opt.customuri, opt.customuriGET, opt.customuriPOST, opt.beacon_PE, opt.processinject_min_alloc, opt.Post_EX_Process_Name, opt.metadata, opt.injector, opt.Host, opt.Profile, opt.ProfilePath, opt.outFile, opt.custom_cert, opt.cert_password, opt.CDN, opt.CDN_Value, opt.Datajitter, opt.Keylogger, opt.Forwarder, opt.tasks_max_size, opt.tasks_proxy_max_size, opt.tasks_dns_proxy_max_size, opt.maxdns)
 }

--- a/Struct/Struct.go
+++ b/Struct/Struct.go
@@ -1293,25 +1293,22 @@ set tcp_frame_header "";
 set ssh_banner "{{.Variables.SSH_Banner}}";
 set ssh_pipename "{{.Variables.SSH_pipename}}##";
 
-####Manaully add these if your doing C2 over DNS (Future Release)####
-##dns-beacon {
-#    set dns_idle             "1.2.3.4";
-#    set dns_max_txt          "199";
-#    set dns_sleep            "1";
-#    set dns_ttl              "5";
-#    set maxdns               "200";
-#    set dns_stager_prepend   "doc-stg-prepend";
-#    set dns_stager_subhost   "doc-stg-sh.";
 
-#    set beacon               "doc.bc.";
-#    set get_A                "doc.1a.";
-#    set get_AAAA             "doc.4a.";
-#    set get_TXT              "doc.tx.";
-#    set put_metadata         "doc.md.";
-#    set put_output           "doc.po.";
-#    set ns_response          "zero";
-
-#}
+dns-beacon {
+	set dns_idle              "{{.Variables.dns_idle}}";
+	set maxdns                "{{.Variables.maxdns}}";
+	set dns_sleep             "{{.Variables.dns_sleep}}";
+	set dns_ttl               "{{.Variables.dns_ttl}}";
+	set dns_stager_prepend    "{{.Variables.dns_stager_prepend}}"; 
+	set dns_stager_subhost    "{{.Variables.dns_stager_subhost}}";
+	set beacon                "{{.Variables.beacon}}";
+	set get_A                 "{{.Variables.get_A}}";
+	set get_AAAA              "{{.Variables.get_AAAA}}";
+	set get_TXT               "{{.Variables.get_TXT}}";
+	set put_metadata          "{{.Variables.put_metadata}}";
+	set put_output            "{{.Variables.put_output}}";
+	set ns_response           "{{.Variables.ns_response}}";
+  }
 
 `
 }

--- a/Struct/Struct.go
+++ b/Struct/Struct.go
@@ -11,7 +11,7 @@ var Profile_Names = []string{
 	`Field-Keyword`,
 	`Custom`}
 
-var Post_EX_Process_Name = []string{`
+	var Post_EX_Process_Name = []string{`
 	set spawnto_x86 "%windir%\\syswow64\\WerFault.exe";
 	set spawnto_x64 "%windir%\\sysnative\\WerFault.exe"; 
 `, `
@@ -33,8 +33,8 @@ var Post_EX_Process_Name = []string{`
 	set spawnto_x86 "%windir%\\syswow64\\bootcfg.exe";
 	set spawnto_x64 "%windir%\sysnative\\bootcfg.exe";
 `, `
-	set spawnto_x86 "%windir%\\syswow64\\dtdump.exe";
-	set spawnto_x64 "%windir%\\sysnative\\dtdump.exe";
+	set spawnto_x86 "%windir%\\syswow64\\w32tm.exe";
+	set spawnto_x64 "%windir%\\sysnative\\w32tm.exe";
 `, `
 	set spawnto_x86 "%windir%\\syswow64\\expand.exe";
 	set spawnto_x64 "%windir%\\sysnative\\expand.exe";
@@ -1595,6 +1595,9 @@ post-ex {
 	
 	# control the method used to log keystrokes 
 	set keylogger "{{.Variables.Keylogger}}";
+
+	# change our post-ex output named pipe names... 
+	set pipename "{{.Variables.pipename}}_####, pipe\\{{.Variables.pipename}}_##";
 }
 `
 }


### PR DESCRIPTION
- Added DNS support. Idle DNS points to a Microsoft owned ip.
- Fixed one of the spawnto targets (dtdump.exe) which did not have a x64 binary. Now targets w32tm